### PR TITLE
Add contributing and code of conduct docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,54 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at luca@scorpiac.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant], version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+For answers to common questions about this Code of Conduct, see the FAQ at https://www.contributor-covenant.org/faq.
+
+[Contributor Covenant]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing to KeyDrive
+
+Thanks for taking the time to contribute to KeyDrive! The main ways you can help is by reporting (or responding to) [issues], creating [pull requests], and participating in [discussions].
+
+## Reporting an Issue
+
+- Check if your issue is already reported by using the search tool. If so, please provide feedback or react to that issue instead of opening a new one.
+- If applicable, attach screenshots to help clarify the problem.
+- Mention the KeyDrive version you are using, the operating system it is running on, and the browser you are using.
+
+## Creating a Pull Request
+
+- Open your pull request against the `main` branch.
+- It should pass all CI checks: passing all tests and the SonarCloud quality gate. This also means adding new (and/or modifying existing) tests to cover your proposed changes.
+
+## Discussions
+
+This is the place for all other community interaction! Here you can discuss ideas for features, ask for help, and everything else that doesn't fit in an issue.
+
+[issues]: https://github.com/keydrive/keydrive/issues
+[pull requests]: https://github.com/keydrive/keydrive/pulls
+[discussions]: https://github.com/keydrive/keydrive/discussions


### PR DESCRIPTION
Closes #93 

A proposal for contributing guidelines and a code of conduct.

The contributing guidelines I tried to keep fairly concise, with just some (fairly obvious) starting points for issues, PRs and discussions. I figured we can adapt these easily enough if there's a need, but it's nice to have a starting point.

For the CoC I took the [Contributor Covenant](https://www.contributor-covenant.org/) (v2.1) as a starting point. Here I made one change of removing the "Enforcement Guidelines" section. While I do think these guidelines are something we could follow, I doubt if it's useful to specify these in the CoC itself. For now I put my email address as the contact method, I can add yours (@ChappIO) there as well, or we could make an email address for the KeyDrive project. I'm fine with all of these ^^

Would love to hear your opinion on, well, all of this @ChappIO :)