### PR TITLE
Replace first and last name fields with name

### DIFF
--- a/internal/controller/Download.go
+++ b/internal/controller/Download.go
@@ -1,11 +1,11 @@
 package controller
 
 import (
-	"keydrive/internal/model"
-	"keydrive/internal/service"
 	"fmt"
 	"github.com/gin-gonic/gin"
 	"io"
+	"keydrive/internal/model"
+	"keydrive/internal/service"
 	"strings"
 )
 

--- a/internal/controller/DownloadToken.go
+++ b/internal/controller/DownloadToken.go
@@ -1,8 +1,8 @@
 package controller
 
 import (
-	"keydrive/internal/service"
 	"github.com/gin-gonic/gin"
+	"keydrive/internal/service"
 	"net/http"
 )
 

--- a/internal/controller/Download_test.go
+++ b/internal/controller/Download_test.go
@@ -1,8 +1,8 @@
 package controller
 
 import (
-	"keydrive/internal/model"
 	"fmt"
+	"keydrive/internal/model"
 	"net/http"
 	"net/http/httptest"
 	"os"

--- a/internal/controller/Entries.go
+++ b/internal/controller/Entries.go
@@ -1,10 +1,10 @@
 package controller
 
 import (
-	"keydrive/internal/model"
-	"keydrive/internal/service"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
+	"keydrive/internal/model"
+	"keydrive/internal/service"
 	"mime/multipart"
 	"net/http"
 	"os"

--- a/internal/controller/Entries_test.go
+++ b/internal/controller/Entries_test.go
@@ -1,9 +1,9 @@
 package controller
 
 import (
+	"fmt"
 	"keydrive/internal/model"
 	"keydrive/internal/service"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"

--- a/internal/controller/Libraries.go
+++ b/internal/controller/Libraries.go
@@ -1,11 +1,11 @@
 package controller
 
 import (
-	"keydrive/internal/model"
-	"keydrive/internal/service"
 	"fmt"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
+	"keydrive/internal/model"
+	"keydrive/internal/service"
 	"net/http"
 	"os"
 	"path/filepath"

--- a/internal/controller/Libraries_test.go
+++ b/internal/controller/Libraries_test.go
@@ -1,8 +1,8 @@
 package controller
 
 import (
-	"keydrive/internal/model"
 	"fmt"
+	"keydrive/internal/model"
 	"net/http/httptest"
 	"testing"
 )

--- a/internal/controller/OAuth.go
+++ b/internal/controller/OAuth.go
@@ -1,10 +1,10 @@
 package controller
 
 import (
-	"keydrive/internal/model"
-	"keydrive/internal/service"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"keydrive/internal/model"
+	"keydrive/internal/service"
 	"net/http"
 	"strings"
 )

--- a/internal/controller/System.go
+++ b/internal/controller/System.go
@@ -1,10 +1,10 @@
 package controller
 
 import (
-	"keydrive/internal/service"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 	"io/ioutil"
+	"keydrive/internal/service"
 	"net/http"
 	"path/filepath"
 )

--- a/internal/controller/User.go
+++ b/internal/controller/User.go
@@ -1,9 +1,9 @@
 package controller
 
 import (
-	"keydrive/internal/service"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
+	"keydrive/internal/service"
 	"net/http"
 )
 
@@ -46,11 +46,8 @@ func UpdateAuthenticatedUser(db *gorm.DB, pwdEnc *service.BcryptEncoder) gin.Han
 			if update.Username != "" {
 				user.Username = update.Username
 			}
-			if update.FirstName != "" {
-				user.FirstName = update.FirstName
-			}
-			if update.LastName != "" {
-				user.LastName = update.LastName
+			if update.Name != "" {
+				user.Name = update.Name
 			}
 			if update.Password != "" {
 				user.HashedPassword = pwdEnc.Encode(update.Password)

--- a/internal/controller/Users.go
+++ b/internal/controller/Users.go
@@ -1,19 +1,18 @@
 package controller
 
 import (
-	"keydrive/internal/model"
-	"keydrive/internal/service"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
+	"keydrive/internal/model"
+	"keydrive/internal/service"
 	"net/http"
 )
 
 type UserSummary struct {
-	ID        int    `json:"id"`
-	FirstName string `json:"firstName"`
-	LastName  string `json:"lastName"`
-	Username  string `json:"username"`
-	IsAdmin   bool   `json:"isAdmin"`
+	ID       int    `json:"id"`
+	Name     string `json:"name"`
+	Username string `json:"username"`
+	IsAdmin  bool   `json:"isAdmin"`
 }
 
 type UserPage struct {
@@ -38,10 +37,9 @@ func ListUsers(db *gorm.DB, users *service.User) gin.HandlerFunc {
 }
 
 type CreateUserDTO struct {
-	Username  string `json:"username" binding:"required"`
-	FirstName string `json:"firstName" binding:"required"`
-	LastName  string `json:"lastName" binding:"required"`
-	Password  string `json:"password" binding:"required"`
+	Username string `json:"username" binding:"required"`
+	Name     string `json:"name" binding:"required"`
+	Password string `json:"password" binding:"required"`
 }
 
 // CreateUser
@@ -61,8 +59,7 @@ func CreateUser(db *gorm.DB, pwdEnc *service.BcryptEncoder) gin.HandlerFunc {
 			return
 		}
 		newUser := model.User{
-			FirstName:      create.FirstName,
-			LastName:       create.LastName,
+			Name:           create.Name,
 			Username:       create.Username,
 			HashedPassword: pwdEnc.Encode(create.Password),
 		}
@@ -99,10 +96,9 @@ func GetUser(db *gorm.DB, users *service.User) gin.HandlerFunc {
 }
 
 type UpdateUserDTO struct {
-	Username  string `json:"username" binding:""`
-	FirstName string `json:"firstName" binding:""`
-	LastName  string `json:"lastName" binding:""`
-	Password  string `json:"password" binding:""`
+	Username string `json:"username" binding:""`
+	Name     string `json:"name" binding:""`
+	Password string `json:"password" binding:""`
 }
 
 // UpdateUser
@@ -135,11 +131,8 @@ func UpdateUser(db *gorm.DB, users *service.User, pwdEnc *service.BcryptEncoder)
 			if update.Username != "" {
 				user.Username = update.Username
 			}
-			if update.FirstName != "" {
-				user.FirstName = update.FirstName
-			}
-			if update.LastName != "" {
-				user.LastName = update.LastName
+			if update.Name != "" {
+				user.Name = update.Name
 			}
 			if update.Password != "" {
 				user.HashedPassword = pwdEnc.Encode(update.Password)

--- a/internal/controller/app.go
+++ b/internal/controller/app.go
@@ -1,13 +1,13 @@
 package controller
 
 import (
-	"keydrive/internal/model"
-	"keydrive/internal/service"
-	"keydrive/web/build"
 	"errors"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 	glog "gorm.io/gorm/logger"
+	"keydrive/internal/model"
+	"keydrive/internal/service"
+	"keydrive/web/build"
 	"net/http"
 	"os"
 	"time"
@@ -50,7 +50,6 @@ func NewApp(dbDiag gorm.Dialector) (app App, err error) {
 		}
 	}
 
-
 	log.Info("connected")
 	log.Info("starting automigration...")
 
@@ -69,8 +68,7 @@ func NewApp(dbDiag gorm.Dialector) (app App, err error) {
 		log.Info("password: admin")
 		app.DB.Save(&model.User{
 			ID:             1,
-			FirstName:      "Super",
-			LastName:       "Admin",
+			Name:           "Admin",
 			Username:       "admin",
 			HashedPassword: "$2y$12$3fvGYrtMSKiow6gvb.K0Q.c4AMhItCQcv5MU7pYNypZii/R.li2o2",
 		})

--- a/internal/controller/json.go
+++ b/internal/controller/json.go
@@ -1,11 +1,11 @@
 package controller
 
 import (
-	"keydrive/pkg/logger"
 	"errors"
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
 	"gorm.io/gorm"
+	"keydrive/pkg/logger"
 	"net/http"
 	"os"
 	"strings"

--- a/internal/controller/setup_test.go
+++ b/internal/controller/setup_test.go
@@ -1,13 +1,13 @@
 package controller
 
 import (
-	"keydrive/internal/model"
 	"database/sql"
 	"fmt"
 	"github.com/google/uuid"
 	_ "github.com/jackc/pgx/v4/stdlib"
 	"gorm.io/driver/postgres"
 	"io"
+	"keydrive/internal/model"
 	"math/rand"
 	"net/http"
 	"os"
@@ -108,8 +108,7 @@ func TestMain(m *testing.M) {
 
 	lonelyUser := model.User{
 		Username:       "no-access",
-		FirstName:      "I have",
-		LastName:       "access to nothing",
+		Name:           "I have access to nothing",
 		HashedPassword: "4fr0u892430u82t8u0tu2308t20u9",
 	}
 	testApp.DB.Create(&lonelyUser)
@@ -118,8 +117,7 @@ func TestMain(m *testing.M) {
 
 	regularUser = model.User{
 		Username:       "simple-access",
-		FirstName:      "I have",
-		LastName:       "access to some stuff",
+		Name:           "I have access to some stuff",
 		HashedPassword: "4fr0u892430u82t8u0tu2308t20u9",
 	}
 	testApp.DB.Create(&regularUser)

--- a/internal/model/User.go
+++ b/internal/model/User.go
@@ -3,8 +3,7 @@ package model
 type User struct {
 	ID             int    `json:"id"`
 	Username       string `json:"username" gorm:"not null;unique;type:citext"`
-	FirstName      string `json:"firstName" gorm:"not null"`
-	LastName       string `json:"lastName" gorm:"not null"`
+	Name           string `json:"name" gorm:"not null;default:''"`
 	HashedPassword string `json:"-" gorm:"not null"`
 	IsAdmin        bool   `json:"isAdmin" gorm:"->;type:boolean GENERATED ALWAYS AS (id = 1) STORED"`
 }

--- a/internal/service/DownloadTokens.go
+++ b/internal/service/DownloadTokens.go
@@ -1,8 +1,8 @@
 package service
 
 import (
-	"keydrive/internal/model"
 	"github.com/google/uuid"
+	"keydrive/internal/model"
 )
 
 type DownloadTokens struct {

--- a/internal/service/FileCategories_test.go
+++ b/internal/service/FileCategories_test.go
@@ -1,8 +1,8 @@
 package service
 
 import (
-	"keydrive/internal/model"
 	"fmt"
+	"keydrive/internal/model"
 	"testing"
 )
 

--- a/internal/service/FileSystem.go
+++ b/internal/service/FileSystem.go
@@ -1,10 +1,10 @@
 package service
 
 import (
-	"keydrive/internal/model"
 	"errors"
 	"io"
 	"io/ioutil"
+	"keydrive/internal/model"
 	"mime/multipart"
 	"os"
 	"path/filepath"

--- a/internal/service/FileSystem_test.go
+++ b/internal/service/FileSystem_test.go
@@ -1,8 +1,8 @@
 package service
 
 import (
-	"keydrive/internal/model"
 	"io"
+	"keydrive/internal/model"
 	"os"
 	"path/filepath"
 	"testing"

--- a/internal/service/Library.go
+++ b/internal/service/Library.go
@@ -1,8 +1,8 @@
 package service
 
 import (
-	"keydrive/internal/model"
 	"gorm.io/gorm"
+	"keydrive/internal/model"
 )
 
 type Library struct {

--- a/internal/service/Token.go
+++ b/internal/service/Token.go
@@ -1,9 +1,9 @@
 package service
 
 import (
-	"keydrive/internal/model"
 	"context"
 	"gorm.io/gorm"
+	"keydrive/internal/model"
 )
 
 type Token struct {

--- a/internal/service/User.go
+++ b/internal/service/User.go
@@ -1,8 +1,8 @@
 package service
 
 import (
-	"keydrive/internal/model"
 	"gorm.io/gorm"
+	"keydrive/internal/model"
 )
 
 type User struct {

--- a/internal/swagger/docs.go
+++ b/internal/swagger/docs.go
@@ -859,16 +859,12 @@ var doc = `{
         "controller.CreateUserDTO": {
             "type": "object",
             "required": [
-                "firstName",
-                "lastName",
+                "name",
                 "password",
                 "username"
             ],
             "properties": {
-                "firstName": {
-                    "type": "string"
-                },
-                "lastName": {
+                "name": {
                     "type": "string"
                 },
                 "password": {
@@ -1005,10 +1001,7 @@ var doc = `{
         "controller.UpdateUserDTO": {
             "type": "object",
             "properties": {
-                "firstName": {
-                    "type": "string"
-                },
-                "lastName": {
+                "name": {
                     "type": "string"
                 },
                 "password": {
@@ -1036,16 +1029,13 @@ var doc = `{
         "controller.UserSummary": {
             "type": "object",
             "properties": {
-                "firstName": {
-                    "type": "string"
-                },
                 "id": {
                     "type": "integer"
                 },
                 "isAdmin": {
                     "type": "boolean"
                 },
-                "lastName": {
+                "name": {
                     "type": "string"
                 },
                 "username": {
@@ -1091,16 +1081,13 @@ var doc = `{
         "model.User": {
             "type": "object",
             "properties": {
-                "firstName": {
-                    "type": "string"
-                },
                 "id": {
                     "type": "integer"
                 },
                 "isAdmin": {
                     "type": "boolean"
                 },
-                "lastName": {
+                "name": {
                     "type": "string"
                 },
                 "username": {

--- a/internal/swagger/swagger.json
+++ b/internal/swagger/swagger.json
@@ -841,16 +841,12 @@
         "controller.CreateUserDTO": {
             "type": "object",
             "required": [
-                "firstName",
-                "lastName",
+                "name",
                 "password",
                 "username"
             ],
             "properties": {
-                "firstName": {
-                    "type": "string"
-                },
-                "lastName": {
+                "name": {
                     "type": "string"
                 },
                 "password": {
@@ -987,10 +983,7 @@
         "controller.UpdateUserDTO": {
             "type": "object",
             "properties": {
-                "firstName": {
-                    "type": "string"
-                },
-                "lastName": {
+                "name": {
                     "type": "string"
                 },
                 "password": {
@@ -1018,16 +1011,13 @@
         "controller.UserSummary": {
             "type": "object",
             "properties": {
-                "firstName": {
-                    "type": "string"
-                },
                 "id": {
                     "type": "integer"
                 },
                 "isAdmin": {
                     "type": "boolean"
                 },
-                "lastName": {
+                "name": {
                     "type": "string"
                 },
                 "username": {
@@ -1073,16 +1063,13 @@
         "model.User": {
             "type": "object",
             "properties": {
-                "firstName": {
-                    "type": "string"
-                },
                 "id": {
                     "type": "integer"
                 },
                 "isAdmin": {
                     "type": "boolean"
                 },
-                "lastName": {
+                "name": {
                     "type": "string"
                 },
                 "username": {

--- a/internal/swagger/swagger.yaml
+++ b/internal/swagger/swagger.yaml
@@ -58,17 +58,14 @@ definitions:
     type: object
   controller.CreateUserDTO:
     properties:
-      firstName:
-        type: string
-      lastName:
+      name:
         type: string
       password:
         type: string
       username:
         type: string
     required:
-    - firstName
-    - lastName
+    - name
     - password
     - username
     type: object
@@ -156,9 +153,7 @@ definitions:
     type: object
   controller.UpdateUserDTO:
     properties:
-      firstName:
-        type: string
-      lastName:
+      name:
         type: string
       password:
         type: string
@@ -176,13 +171,11 @@ definitions:
     type: object
   controller.UserSummary:
     properties:
-      firstName:
-        type: string
       id:
         type: integer
       isAdmin:
         type: boolean
-      lastName:
+      name:
         type: string
       username:
         type: string
@@ -213,13 +206,11 @@ definitions:
     type: object
   model.User:
     properties:
-      firstName:
-        type: string
       id:
         type: integer
       isAdmin:
         type: boolean
-      lastName:
+      name:
         type: string
       username:
         type: string

--- a/web/src/App.spec.tsx
+++ b/web/src/App.spec.tsx
@@ -9,7 +9,7 @@ describe('App', () => {
 
   it('loads userdata and libraries on boot', async () => {
     fetchMock.getOnce('/api/user/', {
-      firstName: 'Test',
+      name: 'Test',
     });
     fetchMock.get('/api/libraries/?limit=100', {
       totalElements: 0,
@@ -37,7 +37,7 @@ describe('App', () => {
 
     await waitFor(() => {
       expect(store.getState().libraries.libraries).toHaveLength(2);
-      expect(store.getState().user.currentUser?.firstName).toBe('Test');
+      expect(store.getState().user.currentUser?.name).toBe('Test');
     });
   });
 });

--- a/web/src/pages/SettingsPage.spec.tsx
+++ b/web/src/pages/SettingsPage.spec.tsx
@@ -12,9 +12,8 @@ describe('SettingsPage', () => {
       user: {
         currentUser: {
           id: 1,
-          lastName: 'admin',
+          name: 'Admin',
           username: 'admin',
-          firstName: 'admin',
           isAdmin: true,
         },
       },

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -52,9 +52,7 @@ export const SettingsPage: React.FC = () => {
             <div className="profile-info">
               <img src={userPlaceholder} alt="Profile" />
               <div className="profile-details">
-                <h2>
-                  {user?.firstName} {user?.lastName}
-                </h2>
+                <h2>{user?.name}</h2>
                 <span className="subtitle">{user?.username}</span>
                 {user?.isAdmin && <Tag>admin</Tag>}
               </div>

--- a/web/src/pages/settings/EditProfileModal.tsx
+++ b/web/src/pages/settings/EditProfileModal.tsx
@@ -12,8 +12,7 @@ export interface Props {
 }
 
 export const EditProfileModal: React.FC<Props> = ({ onClose }) => {
-  const [firstName, setFirstName] = useState('');
-  const [lastName, setLastName] = useState('');
+  const [name, setName] = useState('');
   const [username, setUsername] = useState('');
   const [done, setDone] = useState(false);
   const [error, setError] = useState<string>();
@@ -27,8 +26,7 @@ export const EditProfileModal: React.FC<Props> = ({ onClose }) => {
   useEffect(() => {
     if (currentUserData) {
       setUsername(currentUserData.username);
-      setFirstName(currentUserData.firstName);
-      setLastName(currentUserData.lastName);
+      setName(currentUserData.name);
     }
   }, [currentUserData]);
 
@@ -40,8 +38,7 @@ export const EditProfileModal: React.FC<Props> = ({ onClose }) => {
           setError(undefined);
           const action = await dispatch(
             updateCurrentUserAsync({
-              firstName: firstName.trim(),
-              lastName: lastName.trim(),
+              name: name.trim(),
               username: username.trim(),
             })
           );
@@ -57,8 +54,7 @@ export const EditProfileModal: React.FC<Props> = ({ onClose }) => {
         submitLabel="Save"
       >
         <TextInput label="Username:" value={username} onChange={setUsername} id="username" />
-        <TextInput label="First Name:" value={firstName} onChange={setFirstName} id="firstName" />
-        <TextInput label="Last Name:" value={lastName} onChange={setLastName} id="lastName" />
+        <TextInput label="Name:" value={name} onChange={setName} id="name" />
       </Form>
     </Modal>
   );

--- a/web/src/pages/settings/ManageUsersModal.tsx
+++ b/web/src/pages/settings/ManageUsersModal.tsx
@@ -14,8 +14,7 @@ const CreateOrEditUserForm: React.FC<{
   user?: User;
   onDone: (id: number) => void;
 }> = ({ user, onDone }) => {
-  const [firstName, setFirstName] = useState('');
-  const [lastName, setLastName] = useState('');
+  const [name, setName] = useState('');
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');
@@ -24,12 +23,10 @@ const CreateOrEditUserForm: React.FC<{
 
   useEffect(() => {
     if (user) {
-      setFirstName(user.firstName);
-      setLastName(user.lastName);
+      setName(user.name);
       setUsername(user.username);
     } else {
-      setFirstName('');
-      setLastName('');
+      setName('');
       setUsername('');
       setPassword('');
       setConfirm('');
@@ -38,7 +35,7 @@ const CreateOrEditUserForm: React.FC<{
 
   return (
     <>
-      <h2>{user ? `${user.firstName} ${user.lastName}` : 'Add User'}</h2>
+      <h2>{user ? user.name : 'Add User'}</h2>
       <Form
         error={error}
         onSubmit={async () => {
@@ -51,16 +48,14 @@ const CreateOrEditUserForm: React.FC<{
             if (user) {
               const updatedUser = await userService.updateUser(user.id, {
                 username: username.trim(),
-                firstName: firstName.trim(),
-                lastName: lastName.trim(),
+                name: name.trim(),
                 password: password || undefined,
               });
               onDone(updatedUser.id);
             } else {
               const newUser = await userService.createUser({
                 username: username.trim(),
-                firstName: firstName.trim(),
-                lastName: lastName.trim(),
+                name: name.trim(),
                 password,
               });
               onDone(newUser.id);
@@ -76,8 +71,7 @@ const CreateOrEditUserForm: React.FC<{
         submitLabel={user ? 'Save' : 'Add'}
       >
         <TextInput autoFocus required label="Username:" value={username} onChange={setUsername} id="username" />
-        <TextInput required label="First Name:" value={firstName} onChange={setFirstName} id="firstName" />
-        <TextInput required label="Last Name:" value={lastName} onChange={setLastName} id="lastName" />
+        <TextInput required label="Name:" value={name} onChange={setName} id="name" />
         <PasswordInput required={!user} label="Password:" value={password} onChange={setPassword} id="password" />
         <PasswordInput
           required={!user || !!password}
@@ -130,11 +124,9 @@ export const ManageUsersModal: React.FC<Props> = ({ onClose }) => {
           setSelectedUser(undefined);
         }}
       >
-        {({ firstName, lastName, username }) => (
+        {({ name, username }) => (
           <>
-            <h4>
-              {firstName} {lastName}
-            </h4>
+            <h4>{name}</h4>
             <span>{username}</span>
           </>
         )}

--- a/web/src/services/UserService.ts
+++ b/web/src/services/UserService.ts
@@ -4,15 +4,13 @@ import { Injector } from './Injector';
 export interface User {
   id: number;
   username: string;
-  firstName: string;
-  lastName: string;
+  name: string;
   isAdmin: boolean;
 }
 
 export interface CreateUser {
   username: string;
-  firstName: string;
-  lastName: string;
+  name: string;
   password: string;
 }
 


### PR DESCRIPTION
The way we currently have the users set up with a full name feels unnecessary, so I replaced this with a simple "name" field which acts as the display name. Let me know what you think about this @ChappIO ^^ I defaulted it to empty string in the db so any existing instances should keep working.

Also: I ran `go fmt ./...` so a lot of changes are reordered imports :sweat_smile: 
