### PR TITLE
Handle 404s when browsing files

### DIFF
--- a/web/src/pages/FilesPage.spec.tsx
+++ b/web/src/pages/FilesPage.spec.tsx
@@ -993,4 +993,50 @@ describe('FilesPage', () => {
     expect(screen.queryByDisplayValue('Hold On')).toBeNull();
     expect(screen.queryByText('Hold On')).toBeNull();
   });
+
+  it('redirects to files on a 404', async () => {
+    fetchMock.getOnce(
+      {
+        url: 'path:/api/libraries/4/entries',
+        query: {
+          parent: '/nope',
+        },
+        overwriteRoutes: true,
+      },
+      {
+        status: 404,
+        body: {
+          status: 404,
+          error: 'Not Found',
+        },
+      }
+    );
+    fetchMock.getOnce(
+      {
+        url: 'path:/api/libraries/4/entries',
+        query: {
+          path: '/nope',
+        },
+        overwriteRoutes: false,
+      },
+      {
+        status: 404,
+        body: {
+          status: 404,
+          error: 'Not Found',
+        },
+      }
+    );
+
+    const { navigation } = await render(<FilesPage />, {
+      path: '/files/4/%2Fnope',
+      route: '/files/:library/:path?',
+      loggedIn: true,
+      initialState,
+    });
+
+    await waitFor(() => {
+      expect(navigation.pathname).toBe('/files');
+    });
+  });
 });

--- a/web/src/pages/FilesPage.tsx
+++ b/web/src/pages/FilesPage.tsx
@@ -167,8 +167,7 @@ export const FilesPage: React.FC = () => {
       const getCurrentEntity = pathIsRoot ? Promise.resolve(undefined) : libraries.getEntry(libraryId, path);
       const getCurrentChildren = libraries.getEntries(libraryId, path);
 
-      const newCurrentDir = await getCurrentEntity;
-      const newEntries = await getCurrentChildren;
+      const [newCurrentDir, newEntries] = await Promise.all([getCurrentEntity, getCurrentChildren]);
       setCurrentDir(newCurrentDir);
       setEntries(newEntries);
       return newEntries;

--- a/web/src/pages/FilesPage.tsx
+++ b/web/src/pages/FilesPage.tsx
@@ -167,7 +167,6 @@ export const FilesPage: React.FC = () => {
       const getCurrentEntity = pathIsRoot ? Promise.resolve(undefined) : libraries.getEntry(libraryId, path);
       const getCurrentChildren = libraries.getEntries(libraryId, path);
 
-      // TODO: Handle 404 on getCurrentEntity
       const newCurrentDir = await getCurrentEntity;
       const newEntries = await getCurrentChildren;
       setCurrentDir(newCurrentDir);
@@ -181,9 +180,12 @@ export const FilesPage: React.FC = () => {
   const refresh = useCallback(() => {
     return loadEntries().catch((e) => {
       console.error('Error while loading entries:', e);
+      if (e.status === 404) {
+        history.push('/files');
+      }
       return [];
     });
-  }, [loadEntries]);
+  }, [loadEntries, history]);
 
   useEffect(() => {
     // noinspection JSIgnoredPromiseFromCall


### PR DESCRIPTION
Fixes #69 

Redirect to `/files` when encountering a 404. Not necessarily the most elegant solution, but I'm expecting this to be fairly rare, so I think it's good enough.