### PR TITLE
Fix overflow on left panel in modals

### DIFF
--- a/web/src/components/Modal.scss
+++ b/web/src/components/Modal.scss
@@ -50,6 +50,7 @@
 
       & > .items {
         flex-grow: 1;
+        overflow-y: auto;
 
         & > .item {
           padding: 12px;


### PR DESCRIPTION
Good catch, I hadn't created that many libs yet.

Fixes #112 

![image](https://user-images.githubusercontent.com/13708940/135715081-1e660c8b-69de-4e5a-a670-887dfa88c614.png)
